### PR TITLE
Use data-* attributes to specify tweet content

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
         <div class="g-plusone" data-size="medium"></div>
       </li>
       <li>
-        <a href="https://twitter.com/share?text=DroidKaigi%20%7C%202015/04/25%20http%3A%2F%2Fdroidkaigi%2Egithub%2Eio%2F&hashtags=droidkaigi" class="twitter-share-button" data-lang="ja">ツイート</a>
+        <a href="https://twitter.com/share" class="twitter-share-button" data-text="DroidKaigi | 2015/04/25" data-url="http://droidkaigi.github.io/" data-hashtags="droidkaigi" data-lang="ja">ツイート</a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
Tweetの中身でURL部分が重複していたので修正。ついでに`data` attributeで指定するようにしました。
## 現状

![share_a_link_on_twitter](https://cloud.githubusercontent.com/assets/43811/6014206/4b04b390-aba3-11e4-8588-74cc72e84bc3.png)
## 参考

パラメタの仕様
https://dev.twitter.com/web/tweet-button
