### PR TITLE
fix og:image

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   <meta property="og:type" content="website" />
   <meta property="og:title" content="DroidKaigi | 2015/04/25" />
   <meta property="og:site_name" content="DroidKaigi" />
-  <meta property="og:image" content="img/eyecatch.jpg" />
+  <meta property="og:image" content="img/eyecatch.png" />
   <meta property="og:url" content="http://droidkaigi.github.io/" />
   <meta property="og:description" content="DroidKaigiは、エンジニアが主役のAndroidカンファレンスです。 Android技術情報の共有とコミュニケーションを目的に2015/4/25(土)に開催します。" />
 


### PR DESCRIPTION
og:imageが404でfbの共有うまくできなかった
