### PR TITLE
運営主体についての説明を追記

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,6 +270,7 @@
   <div id="team" class="row">
     <h2>Team</h2>
     <p><strong>DroidKaigi</strong> 実行委員会は、Android開発者有志による組織です。</p>
+    <p>代表: <a href="https://github.com/mhidaka">mhidaka</a></p>
     <p><a href="https://github.com/orgs/DroidKaigi/people">DroidKaigi 実行委員会メンバー</a></p>
   </div>
   <div id="inquiry" class="row">


### PR DESCRIPTION
誰が主催するのか、そしてそれはどういう人達なのか、という説明が無かったので追記しました。

ABCなら「日本Androidの会メンバーによる実行委員会」ですが、DroidKaigiサイトにそういう説明が無かったので。
